### PR TITLE
Fix missing variables in run.sh by escaping

### DIFF
--- a/Docker/Docker.sh
+++ b/Docker/Docker.sh
@@ -187,7 +187,7 @@ function shutdown {
 trap shutdown SIGTERM SIGINT
 
 while true; do
-    ./blockheads_server171 --no-exit -o "$world_id" -p "$server_port" 2>&1 | tee -a bhs-server-log.txt
+    ./blockheads_server171 --no-exit -o "\$world_id" -p "\$server_port" 2>&1 | tee -a bhs-server-log.txt
     echo "Server restarted at \$(date)" | tee -a bhs-server-log.txt
     sleep 1
 done

--- a/start.sh
+++ b/start.sh
@@ -220,8 +220,8 @@ function shutdown {
 trap shutdown SIGTERM SIGINT
 
 while true; do
-    ./blockheads_server171 --no-exit -o "$world_id" -p "$server_port" 2>&1 | tee -a bhs-server-log.txt
-    echo "Server restarted at $(date)" | tee -a bhs-server-log.txt
+    ./blockheads_server171 --no-exit -o "\$world_id" -p "\$server_port" 2>&1 | tee -a bhs-server-log.txt
+    echo "Server restarted at \$(date)" | tee -a bhs-server-log.txt
     sleep 1
 done
 EOF


### PR DESCRIPTION
The variables `world_id` and `server_port` meant to be in _run.sh_ are evaluated as empty before being written to _run.sh_ by both _start.sh_ and _Docker.sh_. This means that when using _run.sh_ to start the server, the values stored in `world_id` and `server_port` were unused. Also, the server restart date was similarly evaluated during writing by _start.sh_, and would be stored in _run.sh_ as the time the script was created.
I've escaped them with a backslash (as was already done in _Docker.sh_ for `$(date)`), so the created file now contains the variables as intended. I've tested this on Ubuntu 25.04 and 24.04 using _start.sh_, and I've verified that the _run.sh_ created by docker correctly contains the variables by temporarily adding `cat run.sh` after writing it in _Docker.sh_.