### PR TITLE
Better OS detection and pacman flag

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -83,7 +83,7 @@ declare -a PACKAGES_ARCH=(
     'libxml2'
     'libffi'
     'libnsl'
-    'zlib-ng-compat'
+    'zlib'
     'icu'
     'libdispatch'
 )
@@ -115,7 +115,7 @@ install_packages_debian() {
 
 install_packages_arch() {
     echo "Installing packages for Arch Linux..."
-    $ROOT pacman -Sy --noconfirm --needed "${PACKAGES_ARCH[@]}" || exit 1
+    $ROOT pacman -Sy --needed "${PACKAGES_ARCH[@]}" || exit 1
 }
 
 install_packages() {

--- a/start.sh
+++ b/start.sh
@@ -83,7 +83,7 @@ declare -a PACKAGES_ARCH=(
     'libxml2'
     'libffi'
     'libnsl'
-    'zlib'
+    'zlib-ng-compat'
     'icu'
     'libdispatch'
 )

--- a/start.sh
+++ b/start.sh
@@ -124,8 +124,8 @@ install_packages() {
         exit 1
     fi
     source /etc/os-release
-    case $ID in
-        debian|ubuntu|pop)
+    case $ID_LIKE in
+        debian)
             install_packages_debian
             ;;
         arch)


### PR DESCRIPTION
Using `ID_LIKE` from `/etc/os-release` instead of `ID` would make this script compatible with more Debian-based and Arch-based distros. The only negative side affect could be packages not being found on distantly related distros, but that's not any worse than the current behavior.

I initially was going to replace the `zlib` package with the `zlib-ng-compat` package, but realized last minute that `zlib` is still the default package providing `libz.so` on many systems. Instead I propose removing the `--no-confirm` flag so the conflict can be resolved.